### PR TITLE
[FIX] Corrected path for resources of ui5lab.wordcloud in combineProjects

### DIFF
--- a/combineProjects.js
+++ b/combineProjects.js
@@ -115,7 +115,7 @@ try {
 
 // ui5lab.wordcloud
 try {
-	fs.copySync('./node_modules/ui5lab-wordcloud/dist/', './resources');
+	fs.copySync('./node_modules/ui5lab-wordcloud/dist/resources', './resources');
 	fs.copySync('./node_modules/ui5lab-wordcloud/dist/test-resources', './test');
 } catch (e) {
 	console.log("an error occured post-processing the ui5lab.wordcloud library: " + e.message);


### PR DESCRIPTION
For newly added ui5lib.wordcloud library, the path of /resources was incorrect in the previous PR.
Due to which, deployed resources/ did not have the ui5lab-wordcloud/library.js copied in the correct place.