### PR TITLE
Fixes broken demo URL on openui5-camera

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-eslint": "^19.0.0",
     "grunt-openui5": "^0.12.0",
-    "openui5-camera": "0.0.11",
+    "openui5-camera": "0.0.12",
     "openui5-chartjs": "https://github.com/StErMi/openui5-chartjs",
     "openui5-flatpickr": "https://github.com/StErMi/openui5-flatpickr",
     "openui5-googlemaps": "https://github.com/jasper07/openui5-googlemaps",


### PR DESCRIPTION
Made a minor change on the openui5-camera repo to fix the demo url (after a github nickname change). This change hopefully pulls the latest change to the lab browser.
Thanks